### PR TITLE
(fixes) Allow heroku to import base.py settings on production

### DIFF
--- a/codango/codango/settings/__init__.py
+++ b/codango/codango/settings/__init__.py
@@ -3,3 +3,6 @@ if not os.getenv('CI') and not os.getenv('HEROKU'):
     from django_envie.workroom import convertfiletovars
     convertfiletovars()
     from development import *
+
+if os.getenv('HEROKU') is not None:
+    from production import *

--- a/codango/codango/settings/production.py
+++ b/codango/codango/settings/production.py
@@ -14,3 +14,7 @@ BOWER_PATH = '/app/node_modules/bower'
 
 # Enable Connection Pooling
 DATABASES['default']['ENGINE'] = 'django_postgrespool'
+
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+ALLOWED_HOSTS = ['*']

--- a/codango/manage.py
+++ b/codango/manage.py
@@ -7,4 +7,5 @@ if __name__ == "__main__":
 
     from django.core.management import execute_from_command_line
 
-    execute_from_command_line(sys.argv)
+    args = [argument.decode('UTF-8') for argument in sys.argv]
+    execute_from_command_line(args)


### PR DESCRIPTION
The error was lack of secret key in the settings on production, now allowing Heroku to import production settings