### PR TITLE
[Fix] Restricting allowed files to just PDFS, DOC and DOCX

### DIFF
--- a/codango/resources/forms.py
+++ b/codango/resources/forms.py
@@ -14,7 +14,7 @@ class ResourceForm(ModelForm):
         options={
             'resource_type': 'raw',
             'use_filename': True,
-            'allowed_formats': ['pdf', 'doc', 'docx', 'py', 'js', 'apk']
+            'allowed_formats': ['pdf', 'doc', 'docx']
         })
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Restricting Codango to only accept PDF, DOC and DOCX file types