### PR TITLE
#111504508 Build out REST Endpoints for Resources (CRUD)

### DIFF
--- a/codango/codango/api.py
+++ b/codango/codango/api.py
@@ -16,7 +16,7 @@ urlpatterns = [
     url(r'auth/login/', 'rest_framework_jwt.views.obtain_jwt_token'),
     url(r'auth/logout/', UserLogoutAPIView.as_view(), name='logout'),
     url(r'auth/register/', UserRegisterAPIView.as_view(), name='register'),
-    url(r'^resources/', ResourceListAPIView.as_view()),
+    url(r'^resources/$', ResourceListAPIView.as_view()),
     url(r'^resources/(?P<pk>[0-9]+)', ResourceDetailAPIView.as_view()),
     url(r'^votes/', VoteListAPIView.as_view()),
     url(r'^votes/(?P<pk>[0-9]+)', VoteDetailAPIView.as_view()),

--- a/codango/codango/settings/base.py
+++ b/codango/codango/settings/base.py
@@ -130,7 +130,9 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
-    )
+    ),
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 3
 }
 
 

--- a/codango/resources/api.py
+++ b/codango/resources/api.py
@@ -7,15 +7,11 @@ from rest_framework import generics
 
 class ResourceListAPIView(generics.ListCreateAPIView):
     """For /api/v1/resources/ url path"""
-    # permission_classes = (permissions.AllowAny,)
-
     queryset = Resource.objects.all()
     serializer_class = ResourceSerializer
 
 
 class ResourceDetailAPIView(generics.RetrieveUpdateDestroyAPIView):
     """For /api/v1/resources/<> url path"""
-    # permission_classes = (permissions.AllowAny,)
-
     queryset = Resource.objects.all()
     serializer_class = ResourceSerializer

--- a/codango/resources/api.py
+++ b/codango/resources/api.py
@@ -1,4 +1,4 @@
-from rest_framework import generics
+from rest_framework import generics, permissions
 from serializers import ResourceSerializer
 from models import Resource
 
@@ -7,11 +7,15 @@ from rest_framework import generics
 
 class ResourceListAPIView(generics.ListCreateAPIView):
     """For /api/v1/resources/ url path"""
+    # permission_classes = (permissions.AllowAny,)
+
     queryset = Resource.objects.all()
     serializer_class = ResourceSerializer
 
 
 class ResourceDetailAPIView(generics.RetrieveUpdateDestroyAPIView):
     """For /api/v1/resources/<> url path"""
+    # permission_classes = (permissions.AllowAny,)
+
     queryset = Resource.objects.all()
     serializer_class = ResourceSerializer

--- a/codango/resources/fixtures/resources.json
+++ b/codango/resources/fixtures/resources.json
@@ -1,0 +1,170 @@
+[
+{
+    "fields": {
+        "username": "stan",
+        "first_name": "",
+        "last_name": "",
+        "is_active": true,
+        "is_superuser": true,
+        "is_staff": true,
+        "last_login": "2016-03-10T08:36:22.814Z",
+        "groups": [],
+        "user_permissions": [],
+        "password": "pbkdf2_sha256$20000$eV2IGCXmA5vY$fJ9f2lZywnwyerMcqyQylF28EUVJQsVVKKy2uCxxr6Y=",
+        "email": "stanley.ndagi@andela.com",
+        "date_joined": "2015-09-03T09:01:00.053Z"
+    },
+    "model": "auth.user",
+    "pk": 1
+},
+{
+    "fields": {
+        "author": 1,
+        "text": "Resource1",
+        "language_tags": "Untagged",
+        "resource_file": null,
+        "resource_file_name": null,
+        "resource_file_size": 0,
+        "snippet_text": "",
+        "date_added": "2016-03-01T13:54:52.326929Z",
+        "date_modified": "2016-03-01T13:54:52.326965Z"
+    },
+    "model": "resources.Resource",
+    "pk": 1
+},
+{
+    "fields": {
+        "author": 1,
+        "text": "Resource2",
+        "language_tags": "C",
+        "resource_file": null,
+        "resource_file_name": null,
+        "resource_file_size": 0,
+        "snippet_text": "",
+        "date_added": "2016-03-01T13:54:52.326929Z",
+        "date_modified": "2016-03-01T13:54:52.326965Z"
+    },
+    "model": "resources.Resource",
+    "pk": 2
+},
+{
+    "fields": {
+        "author": 1,
+        "text": "Resource3",
+        "language_tags": "JAVASCRIPT",
+        "resource_file": null,
+        "resource_file_name": null,
+        "resource_file_size": 0,
+        "snippet_text": "",
+        "date_added": "2016-03-01T13:54:52.326929Z",
+        "date_modified": "2016-03-01T13:54:52.326965Z"
+    },
+    "model": "resources.Resource",
+    "pk": 3
+},
+{
+    "fields": {
+        "author": 1,
+        "text": "Resource4",
+        "language_tags": "IOS",
+        "resource_file": null,
+        "resource_file_name": null,
+        "resource_file_size": 0,
+        "snippet_text": "",
+        "date_added": "2016-03-01T13:54:52.326929Z",
+        "date_modified": "2016-03-01T13:54:52.326965Z"
+    },
+    "model": "resources.Resource",
+    "pk": 4
+},
+{
+    "fields": {
+        "author": 1,
+        "text": "Resource5",
+        "language_tags": "PHP",
+        "resource_file": null,
+        "resource_file_name": null,
+        "resource_file_size": 0,
+        "snippet_text": "",
+        "date_added": "2016-03-01T13:54:52.326929Z",
+        "date_modified": "2016-03-01T13:54:52.326965Z"
+    },
+    "model": "resources.Resource",
+    "pk": 5
+},
+{
+    "fields": {
+        "author": 1,
+        "text": "Resource6",
+        "language_tags": "JAVA",
+        "resource_file": null,
+        "resource_file_name": null,
+        "resource_file_size": 0,
+        "snippet_text": "",
+        "date_added": "2016-03-01T13:54:52.326929Z",
+        "date_modified": "2016-03-01T13:54:52.326965Z"
+    },
+    "model": "resources.Resource",
+    "pk": 6
+},
+{
+    "fields": {
+        "author": 1,
+        "text": "Resource7",
+        "language_tags": "MARKUP",
+        "resource_file": null,
+        "resource_file_name": null,
+        "resource_file_size": 0,
+        "snippet_text": "",
+        "date_added": "2016-03-01T13:54:52.326929Z",
+        "date_modified": "2016-03-01T13:54:52.326965Z"
+    },
+    "model": "resources.Resource",
+    "pk": 7
+},
+{
+    "fields": {
+        "author": 1,
+        "text": "Resource8",
+        "language_tags": "ANDROID",
+        "resource_file": null,
+        "resource_file_name": null,
+        "resource_file_size": 0,
+        "snippet_text": "",
+        "date_added": "2016-03-01T13:54:52.326929Z",
+        "date_modified": "2016-03-01T13:54:52.326965Z"
+    },
+    "model": "resources.Resource",
+    "pk": 8
+},
+{
+    "fields": {
+        "author": 1,
+        "text": "Resource9",
+        "language_tags": "RUBY",
+        "resource_file": null,
+        "resource_file_name": null,
+        "resource_file_size": 0,
+        "snippet_text": "",
+        "date_added": "2016-03-01T13:54:52.326929Z",
+        "date_modified": "2016-03-01T13:54:52.326965Z"
+    },
+    "model": "resources.Resource",
+    "pk": 9
+},
+{
+    "fields": {
+        "author": 1,
+        "text": "Resource10",
+        "language_tags": "PYTHON",
+        "resource_file": null,
+        "resource_file_name": null,
+        "resource_file_size": 0,
+        "snippet_text": "",
+        "date_added": "2016-03-01T13:54:52.326929Z",
+        "date_modified": "2016-03-01T13:54:52.326965Z"
+    },
+    "model": "resources.Resource",
+    "pk": 10
+}
+]

--- a/codango/resources/tests/test_api.py
+++ b/codango/resources/tests/test_api.py
@@ -12,6 +12,15 @@ message = {"detail":
 class ResourceTest(APITestCase):
     """Test /api/v1/resources/ endpoint"""
 
+    def setUp(self):
+        # Register the user
+        self.client.post('/api/v1/auth/register/', user, format='json')
+        # Login the user
+        auth_user = {'username': User.objects.get().username,
+                     'password': user['password']}
+        login_response = self.client.post('/api/v1/auth/login/', auth_user)
+        self.token = 'JWT ' + login_response.data.get('token')
+
     def test_C_resource(self):
         """Test Create resource"""
 
@@ -22,16 +31,8 @@ class ResourceTest(APITestCase):
         self.assertNotEqual(plain_response.data, {})
         self.assertEqual(plain_response.status_code, 401)
 
-        # Register the user
-        self.client.post('/api/v1/auth/register/', user, format='json')
-        # Login the user
-        auth_user = {'username': User.objects.get().username,
-                     'password': user['password']}
-        login_response = self.client.post('/api/v1/auth/login/', auth_user)
-        token = 'JWT ' + login_response.data.get('token')
-
         # set authentication token in header
-        self.client.credentials(HTTP_AUTHORIZATION=token)
+        self.client.credentials(HTTP_AUTHORIZATION=self.token)
         # Get to the resources url
         auth_response = self.client.post(url, entry)
         self.assertEqual(auth_response.data.get('text'), 'abcdefgh')
@@ -48,16 +49,8 @@ class ResourceTest(APITestCase):
         self.assertNotEqual(plain_response.data, {})
         self.assertEqual(plain_response.status_code, 401)
 
-        # Register the user
-        self.client.post('/api/v1/auth/register/', user, format='json')
-        # Login the user
-        auth_user = {'username': User.objects.get().username,
-                     'password': user['password']}
-        login_response = self.client.post('/api/v1/auth/login/', auth_user)
-        token = 'JWT ' + login_response.data.get('token')
-
         # set authentication token in header
-        self.client.credentials(HTTP_AUTHORIZATION=token)
+        self.client.credentials(HTTP_AUTHORIZATION=self.token)
         # Get to the resources url
         auth_response = self.client.get(url)
         self.assertEqual(auth_response.data['results'], [])
@@ -95,16 +88,8 @@ class ResourceTest(APITestCase):
         self.assertNotEqual(plain_response.data, {})
         self.assertEqual(plain_response.status_code, 401)
 
-        # Register the user
-        self.client.post('/api/v1/auth/register/', user, format='json')
-        # Login the user
-        auth_user = {'username': User.objects.get().username,
-                     'password': user['password']}
-        login_response = self.client.post('/api/v1/auth/login/', auth_user)
-        token = 'JWT ' + login_response.data.get('token')
-
         # set authentication token in header
-        self.client.credentials(HTTP_AUTHORIZATION=token)
+        self.client.credentials(HTTP_AUTHORIZATION=self.token)
         not_found_msg = {"detail": "Not found."}
         # Get to the specific resources url
         auth_response = self.client.get('/api/v1/resources/1')
@@ -136,15 +121,8 @@ class ResourceTest(APITestCase):
         self.assertNotEqual(plain_response.data, {})
         self.assertEqual(plain_response.status_code, 401)
 
-        # Register the user
-        self.client.post('/api/v1/auth/register/', user, format='json')
-        # Login the user
-        auth_user = {'username': User.objects.get().username,
-                     'password': user['password']}
-        login_response = self.client.post('/api/v1/auth/login/', auth_user)
-        token = 'JWT ' + login_response.data.get('token')
         # set authentication token in header
-        self.client.credentials(HTTP_AUTHORIZATION=token)
+        self.client.credentials(HTTP_AUTHORIZATION=self.token)
 
         not_found_msg = {"detail": "Not found."}
         # Get to the specific resources url
@@ -172,16 +150,8 @@ class ResourceTest(APITestCase):
         self.assertNotEqual(plain_response.data, {})
         self.assertEqual(plain_response.status_code, 401)
 
-        # Register the user
-        self.client.post('/api/v1/auth/register/', user, format='json')
-        # Login the user
-        auth_user = {'username': User.objects.get().username,
-                     'password': user['password']}
-        login_response = self.client.post('/api/v1/auth/login/', auth_user)
-        token = 'JWT ' + login_response.data.get('token')
-
         # set authentication token in header
-        self.client.credentials(HTTP_AUTHORIZATION=token)
+        self.client.credentials(HTTP_AUTHORIZATION=self.token)
         not_found_msg = {"detail": "Not found."}
         # Get to the specific resources url
         auth_response = self.client.get('/api/v1/resources/1')

--- a/codango/resources/tests/test_api.py
+++ b/codango/resources/tests/test_api.py
@@ -4,10 +4,13 @@ from rest_framework.test import APITestCase
 from django.contrib.auth.models import User
 from ..models import Resource
 
+# DRY variables to be used repeatedly
 user = {'username': 'stanmd', 'email': 'ndagi@gmail.com', 'password': '1234'}
 message = {"detail":
            "Authentication credentials were not provided."}
-
+url = '/api/v1/resources/'
+url_for_one = '/api/v1/resources/5'
+not_found_msg = {"detail": "Not found."}
 
 class ResourceTest(APITestCase):
     """Test /api/v1/resources/ endpoint"""
@@ -24,7 +27,6 @@ class ResourceTest(APITestCase):
     def test_C_resource(self):
         """Test Create resource"""
 
-        url = '/api/v1/resources/'
         entry = {'author': 1, 'text': "abcdefgh", 'language_tags': "PYTHON"}
         plain_response = self.client.post(url, entry)
         self.assertEqual(plain_response.data, message)
@@ -33,17 +35,16 @@ class ResourceTest(APITestCase):
 
         # set authentication token in header
         self.client.credentials(HTTP_AUTHORIZATION=self.token)
-        # Get to the resources url
         auth_response = self.client.post(url, entry)
+
         self.assertEqual(auth_response.data.get('text'), 'abcdefgh')
         self.assertEqual(auth_response.status_code, 201)
-        self.assertNotEqual(plain_response.data, {})
+        self.assertNotEqual(auth_response.data, {})
         self.assertEqual(Resource.objects.count(), 1)
 
     def test_R_resource(self):
         """Test Retrieve resources"""
 
-        url = '/api/v1/resources/'
         plain_response = self.client.get(url)
         self.assertEqual(plain_response.data, message)
         self.assertNotEqual(plain_response.data, {})
@@ -51,20 +52,25 @@ class ResourceTest(APITestCase):
 
         # set authentication token in header
         self.client.credentials(HTTP_AUTHORIZATION=self.token)
-        # Get to the resources url
         auth_response = self.client.get(url)
+
         self.assertEqual(auth_response.data['results'], [])
         self.assertEqual(auth_response.status_code, 200)
-        self.assertNotEqual(plain_response.data, {})
+        self.assertNotEqual(auth_response.data, {})
 
+    def test_pagination_resource(self):
         """Test pagination"""
+
+        # set authentication token in header
+        self.client.credentials(HTTP_AUTHORIZATION=self.token)
         # Create several resources
         for i in range(10):
             entry = {'author': User.objects.get().id,
-                     'text': "Resource%d" %i,
+                     'text': "Resource%d" % i,
                      'language_tags': "PYTHON"}
             self.client.post(url, entry)
         auth_response = self.client.get(url)
+
         # According to the number specified in the settings/base.py
         self.assertEqual(auth_response.data['count'], 10)
         self.assertEqual(auth_response.data['next'],
@@ -73,7 +79,7 @@ class ResourceTest(APITestCase):
         self.assertEqual(auth_response.data['previous'], None)
         self.assertEqual(len(auth_response.data['results']), 3)
         self.assertEqual(auth_response.status_code, 200)
-        self.assertNotEqual(plain_response.data, {})
+        self.assertNotEqual(auth_response.data, {})
         next_page_url = '/api/v1/resources/?page=2'
         self.assertEqual(self.client.get(next_page_url).data['next'],
                          "http://testserver/api/v1/resources/?page=3")
@@ -83,53 +89,52 @@ class ResourceTest(APITestCase):
 
     def test_R_specific_resource(self):
         """Test Retrieve specific resource"""
-        plain_response = self.client.get('/api/v1/resources/1')
+        plain_response = self.client.get(url_for_one)
         self.assertEqual(plain_response.data, message)
         self.assertNotEqual(plain_response.data, {})
         self.assertEqual(plain_response.status_code, 401)
 
         # set authentication token in header
         self.client.credentials(HTTP_AUTHORIZATION=self.token)
-        not_found_msg = {"detail": "Not found."}
-        # Get to the specific resources url
-        auth_response = self.client.get('/api/v1/resources/1')
+        auth_response = self.client.get(url_for_one)
+
         self.assertEqual(auth_response.data, not_found_msg)
         self.assertEqual(auth_response.status_code, 404)
-        self.assertNotEqual(plain_response.data, {})
+        self.assertNotEqual(auth_response.data, {})
 
         # Create several resources
         for i in range(10):
             entry = {'author': User.objects.get().id,
                      'text': "Resource%d" %i,
                      'language_tags': "PYTHON"}
-            self.client.post('/api/v1/resources/', entry)
-        auth_response = self.client.get('/api/v1/resources/5')
+            self.client.post(url, entry)
+        auth_response = self.client.get(url_for_one)
         self.assertNotEqual(auth_response.data, not_found_msg)
         self.assertEqual(auth_response.status_code, 200)
         self.assertEqual(auth_response.data.get('text'), 'Resource4')
 
     def test_U_specific_resource(self):
         """Test Update specific resource"""
+
         update_info = {"author": 1, "text": "Test Update",
                        "language_tags": "PYTHON", "resource_file": 'None',
                        "resource_file_name": 'None', "resource_file_size": 0,
                        "snippet_text": "random Text",
                        "date_added": "2016-03-01T13:54:52.326929Z",
                        "date_modified": "2016-03-01T13:54:52.326965Z"}
-        plain_response = self.client.put('/api/v1/resources/1', update_info)
+        plain_response = self.client.put(url_for_one, update_info)
         self.assertEqual(plain_response.data, message)
         self.assertNotEqual(plain_response.data, {})
         self.assertEqual(plain_response.status_code, 401)
 
         # set authentication token in header
         self.client.credentials(HTTP_AUTHORIZATION=self.token)
-
-        not_found_msg = {"detail": "Not found."}
         # Get to the specific resources url
-        auth_response = self.client.get('/api/v1/resources/1')
+        auth_response = self.client.get(url_for_one)
+
         self.assertEqual(auth_response.data, not_found_msg)
         self.assertEqual(auth_response.status_code, 404)
-        self.assertNotEqual(plain_response.data, {})
+        self.assertNotEqual(auth_response.data, {})
 
         # Create several resources
         for i in range(10):
@@ -137,32 +142,35 @@ class ResourceTest(APITestCase):
                      'text': "Resource%d" % i,
                      'language_tags': "PYTHON"}
             self.client.post('/api/v1/resources/', entry)
-        auth_response = self.client.put('/api/v1/resources/5', update_info)
+        auth_response = self.client.put(url_for_one, update_info)
         self.assertNotEqual(auth_response.data, not_found_msg)
         self.assertEqual(auth_response.status_code, 200)
         self.assertNotEqual(auth_response.data.get('text'), 'Resource4')
         self.assertEqual(auth_response.data.get('text'), 'Test Update')
 
     def test_D_specific_resource(self):
-        """Test Update specific resource"""
-        plain_response = self.client.delete('/api/v1/resources/1')
+        """Test Delete specific resource"""
+
+        plain_response = self.client.delete(url_for_one)
         self.assertEqual(plain_response.data, message)
         self.assertNotEqual(plain_response.data, {})
         self.assertEqual(plain_response.status_code, 401)
 
         # set authentication token in header
         self.client.credentials(HTTP_AUTHORIZATION=self.token)
-        not_found_msg = {"detail": "Not found."}
-        # Get to the specific resources url
-        auth_response = self.client.get('/api/v1/resources/1')
+        auth_response = self.client.get(url_for_one)
+
         self.assertEqual(auth_response.data, not_found_msg)
         self.assertEqual(auth_response.status_code, 404)
-        self.assertNotEqual(plain_response.data, {})
+        self.assertNotEqual(auth_response.data, {})
 
         # Create several resources
         for i in range(10):
-            entry = {'author': User.objects.get().id, 'text': "Resource%d" %i, 'language_tags': "PYTHON"}
+            entry = {'author': User.objects.get().id,
+                     'text': "Resource%d" % i,
+                     'language_tags': "PYTHON"}
             self.client.post('/api/v1/resources/', entry)
-        auth_response = self.client.delete('/api/v1/resources/5')
+        auth_response = self.client.delete(url_for_one)
         self.assertEqual(auth_response.data, None)
+        self.assertEqual(self.client.get(url).data['count'], 9)
         self.assertEqual(auth_response.status_code, 204)

--- a/codango/resources/tests/test_api.py
+++ b/codango/resources/tests/test_api.py
@@ -14,6 +14,7 @@ class ResourceTest(APITestCase):
 
     def test_R_resource(self):
         """Test Retrieve resource"""
+
         url = '/api/v1/resources/'
         plain_response = self.client.get(url)
         self.assertEqual(plain_response.data, message)
@@ -23,13 +24,13 @@ class ResourceTest(APITestCase):
         # Register the user
         self.client.post('/api/v1/auth/register/', user, format='json')
         # Login the user
-        auth_user = {'username': User.objects.get().username, 'password': user['password']}
+        auth_user = {'username': User.objects.get().username,
+                     'password': user['password']}
         login_response = self.client.post('/api/v1/auth/login/', auth_user)
-
         token = 'JWT ' + login_response.data.get('token')
+
         # set authentication token in header
         self.client.credentials(HTTP_AUTHORIZATION=token)
-
         # Get to the resources url
         auth_response = self.client.get(url)
         self.assertEqual(auth_response.data['results'], [])
@@ -38,8 +39,9 @@ class ResourceTest(APITestCase):
 
 
     def test_C_resource(self):
-        url = '/api/v1/resources/'
         """Test Create resource"""
+
+        url = '/api/v1/resources/'
         entry = {'author': 1, 'text': "abcdefgh", 'language_tags': "PYTHON"}
         plain_response = self.client.post(url, entry)
         self.assertEqual(plain_response.data, message)
@@ -49,16 +51,15 @@ class ResourceTest(APITestCase):
         # Register the user
         self.client.post('/api/v1/auth/register/', user, format='json')
         # Login the user
-        auth_user = {'username': User.objects.get().username, 'password': user['password']}
+        auth_user = {'username': User.objects.get().username,
+                     'password': user['password']}
         login_response = self.client.post('/api/v1/auth/login/', auth_user)
-
         token = 'JWT ' + login_response.data.get('token')
+
         # set authentication token in header
         self.client.credentials(HTTP_AUTHORIZATION=token)
-
         # Get to the resources url
         auth_response = self.client.post(url, entry)
-        import ipdb; ipdb.set_trace()
         self.assertEqual(auth_response.data.get('text'), 'abcdefgh')
         self.assertEqual(auth_response.status_code, 201)
         self.assertNotEqual(plain_response.data, {})

--- a/codango/resources/tests/test_api.py
+++ b/codango/resources/tests/test_api.py
@@ -12,32 +12,6 @@ message = {"detail":
 class ResourceTest(APITestCase):
     """Test /api/v1/resources/ endpoint"""
 
-    def test_R_resource(self):
-        """Test Retrieve resource"""
-
-        url = '/api/v1/resources/'
-        plain_response = self.client.get(url)
-        self.assertEqual(plain_response.data, message)
-        self.assertNotEqual(plain_response.data, {})
-        self.assertEqual(plain_response.status_code, 401)
-
-        # Register the user
-        self.client.post('/api/v1/auth/register/', user, format='json')
-        # Login the user
-        auth_user = {'username': User.objects.get().username,
-                     'password': user['password']}
-        login_response = self.client.post('/api/v1/auth/login/', auth_user)
-        token = 'JWT ' + login_response.data.get('token')
-
-        # set authentication token in header
-        self.client.credentials(HTTP_AUTHORIZATION=token)
-        # Get to the resources url
-        auth_response = self.client.get(url)
-        self.assertEqual(auth_response.data['results'], [])
-        self.assertEqual(auth_response.status_code, 200)
-        self.assertNotEqual(plain_response.data, {})
-
-
     def test_C_resource(self):
         """Test Create resource"""
 
@@ -65,19 +39,160 @@ class ResourceTest(APITestCase):
         self.assertNotEqual(plain_response.data, {})
         self.assertEqual(Resource.objects.count(), 1)
 
+    def test_R_resource(self):
+        """Test Retrieve resources"""
 
-    def test_RUD_specific_resource(self):
-        plain_response = self.client.get('/api/v1/resources/')
+        url = '/api/v1/resources/'
+        plain_response = self.client.get(url)
         self.assertEqual(plain_response.data, message)
         self.assertNotEqual(plain_response.data, {})
         self.assertEqual(plain_response.status_code, 401)
 
-    """
-    Will be included in the CRUD of endpoints upon authentication
+        # Register the user
+        self.client.post('/api/v1/auth/register/', user, format='json')
+        # Login the user
+        auth_user = {'username': User.objects.get().username,
+                     'password': user['password']}
+        login_response = self.client.post('/api/v1/auth/login/', auth_user)
+        token = 'JWT ' + login_response.data.get('token')
 
-    TO TEST AUTH PER URL
-    token = 'JWT ' + login_response.data.get('token')
-    # set authentication token in header
-    self.client.credentials(HTTP_AUTHORIZATION=token)
-    auth_response = self.client.post('/api/v1/....')
-    """
+        # set authentication token in header
+        self.client.credentials(HTTP_AUTHORIZATION=token)
+        # Get to the resources url
+        auth_response = self.client.get(url)
+        self.assertEqual(auth_response.data['results'], [])
+        self.assertEqual(auth_response.status_code, 200)
+        self.assertNotEqual(plain_response.data, {})
+
+        """Test pagination"""
+        # Create several resources
+        for i in range(10):
+            entry = {'author': User.objects.get().id,
+                     'text': "Resource%d" %i,
+                     'language_tags': "PYTHON"}
+            self.client.post(url, entry)
+        auth_response = self.client.get(url)
+        # According to the number specified in the settings/base.py
+        self.assertEqual(auth_response.data['count'], 10)
+        self.assertEqual(auth_response.data['next'],
+                         "http://testserver/api/v1/resources/?page=2")
+        # Null in JSON is equal to None in Python
+        self.assertEqual(auth_response.data['previous'], None)
+        self.assertEqual(len(auth_response.data['results']), 3)
+        self.assertEqual(auth_response.status_code, 200)
+        self.assertNotEqual(plain_response.data, {})
+        next_page_url = '/api/v1/resources/?page=2'
+        self.assertEqual(self.client.get(next_page_url).data['next'],
+                         "http://testserver/api/v1/resources/?page=3")
+        self.assertEqual(self.client.get(next_page_url).data['previous'],
+                         "http://testserver/api/v1/resources/")
+        self.assertEqual(len(auth_response.data['results']), 3)
+
+    def test_R_specific_resource(self):
+        """Test Retrieve specific resource"""
+        plain_response = self.client.get('/api/v1/resources/1')
+        self.assertEqual(plain_response.data, message)
+        self.assertNotEqual(plain_response.data, {})
+        self.assertEqual(plain_response.status_code, 401)
+
+        # Register the user
+        self.client.post('/api/v1/auth/register/', user, format='json')
+        # Login the user
+        auth_user = {'username': User.objects.get().username,
+                     'password': user['password']}
+        login_response = self.client.post('/api/v1/auth/login/', auth_user)
+        token = 'JWT ' + login_response.data.get('token')
+
+        # set authentication token in header
+        self.client.credentials(HTTP_AUTHORIZATION=token)
+        not_found_msg = {"detail": "Not found."}
+        # Get to the specific resources url
+        auth_response = self.client.get('/api/v1/resources/1')
+        self.assertEqual(auth_response.data, not_found_msg)
+        self.assertEqual(auth_response.status_code, 404)
+        self.assertNotEqual(plain_response.data, {})
+
+        # Create several resources
+        for i in range(10):
+            entry = {'author': User.objects.get().id,
+                     'text': "Resource%d" %i,
+                     'language_tags': "PYTHON"}
+            self.client.post('/api/v1/resources/', entry)
+        auth_response = self.client.get('/api/v1/resources/5')
+        self.assertNotEqual(auth_response.data, not_found_msg)
+        self.assertEqual(auth_response.status_code, 200)
+        self.assertEqual(auth_response.data.get('text'), 'Resource4')
+
+    def test_U_specific_resource(self):
+        """Test Update specific resource"""
+        update_info = {"author": 1, "text": "Test Update",
+                       "language_tags": "PYTHON", "resource_file": 'None',
+                       "resource_file_name": 'None', "resource_file_size": 0,
+                       "snippet_text": "random Text",
+                       "date_added": "2016-03-01T13:54:52.326929Z",
+                       "date_modified": "2016-03-01T13:54:52.326965Z"}
+        plain_response = self.client.put('/api/v1/resources/1', update_info)
+        self.assertEqual(plain_response.data, message)
+        self.assertNotEqual(plain_response.data, {})
+        self.assertEqual(plain_response.status_code, 401)
+
+        # Register the user
+        self.client.post('/api/v1/auth/register/', user, format='json')
+        # Login the user
+        auth_user = {'username': User.objects.get().username,
+                     'password': user['password']}
+        login_response = self.client.post('/api/v1/auth/login/', auth_user)
+        token = 'JWT ' + login_response.data.get('token')
+        # set authentication token in header
+        self.client.credentials(HTTP_AUTHORIZATION=token)
+
+        not_found_msg = {"detail": "Not found."}
+        # Get to the specific resources url
+        auth_response = self.client.get('/api/v1/resources/1')
+        self.assertEqual(auth_response.data, not_found_msg)
+        self.assertEqual(auth_response.status_code, 404)
+        self.assertNotEqual(plain_response.data, {})
+
+        # Create several resources
+        for i in range(10):
+            entry = {'author': User.objects.get().id,
+                     'text': "Resource%d" % i,
+                     'language_tags': "PYTHON"}
+            self.client.post('/api/v1/resources/', entry)
+        auth_response = self.client.put('/api/v1/resources/5', update_info)
+        self.assertNotEqual(auth_response.data, not_found_msg)
+        self.assertEqual(auth_response.status_code, 200)
+        self.assertNotEqual(auth_response.data.get('text'), 'Resource4')
+        self.assertEqual(auth_response.data.get('text'), 'Test Update')
+
+    def test_D_specific_resource(self):
+        """Test Update specific resource"""
+        plain_response = self.client.delete('/api/v1/resources/1')
+        self.assertEqual(plain_response.data, message)
+        self.assertNotEqual(plain_response.data, {})
+        self.assertEqual(plain_response.status_code, 401)
+
+        # Register the user
+        self.client.post('/api/v1/auth/register/', user, format='json')
+        # Login the user
+        auth_user = {'username': User.objects.get().username,
+                     'password': user['password']}
+        login_response = self.client.post('/api/v1/auth/login/', auth_user)
+        token = 'JWT ' + login_response.data.get('token')
+
+        # set authentication token in header
+        self.client.credentials(HTTP_AUTHORIZATION=token)
+        not_found_msg = {"detail": "Not found."}
+        # Get to the specific resources url
+        auth_response = self.client.get('/api/v1/resources/1')
+        self.assertEqual(auth_response.data, not_found_msg)
+        self.assertEqual(auth_response.status_code, 404)
+        self.assertNotEqual(plain_response.data, {})
+
+        # Create several resources
+        for i in range(10):
+            entry = {'author': User.objects.get().id, 'text': "Resource%d" %i, 'language_tags': "PYTHON"}
+            self.client.post('/api/v1/resources/', entry)
+        auth_response = self.client.delete('/api/v1/resources/5')
+        self.assertEqual(auth_response.data, None)
+        self.assertEqual(auth_response.status_code, 204)

--- a/codango/resources/tests/test_api.py
+++ b/codango/resources/tests/test_api.py
@@ -1,13 +1,71 @@
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from django.contrib.auth.models import User
+from ..models import Resource
+
+user = {'username': 'stanmd', 'email': 'ndagi@gmail.com', 'password': '1234'}
 message = {"detail":
            "Authentication credentials were not provided."}
 
 
 class ResourceTest(APITestCase):
     """Test /api/v1/resources/ endpoint"""
-    def test_resource(self):
+
+    def test_R_resource(self):
+        """Test Retrieve resource"""
+        url = '/api/v1/resources/'
+        plain_response = self.client.get(url)
+        self.assertEqual(plain_response.data, message)
+        self.assertNotEqual(plain_response.data, {})
+        self.assertEqual(plain_response.status_code, 401)
+
+        # Register the user
+        self.client.post('/api/v1/auth/register/', user, format='json')
+        # Login the user
+        auth_user = {'username': User.objects.get().username, 'password': user['password']}
+        login_response = self.client.post('/api/v1/auth/login/', auth_user)
+
+        token = 'JWT ' + login_response.data.get('token')
+        # set authentication token in header
+        self.client.credentials(HTTP_AUTHORIZATION=token)
+
+        # Get to the resources url
+        auth_response = self.client.get(url)
+        self.assertEqual(auth_response.data['results'], [])
+        self.assertEqual(auth_response.status_code, 200)
+        self.assertNotEqual(plain_response.data, {})
+
+
+    def test_C_resource(self):
+        url = '/api/v1/resources/'
+        """Test Create resource"""
+        entry = {'author': 1, 'text': "abcdefgh", 'language_tags': "PYTHON"}
+        plain_response = self.client.post(url, entry)
+        self.assertEqual(plain_response.data, message)
+        self.assertNotEqual(plain_response.data, {})
+        self.assertEqual(plain_response.status_code, 401)
+
+        # Register the user
+        self.client.post('/api/v1/auth/register/', user, format='json')
+        # Login the user
+        auth_user = {'username': User.objects.get().username, 'password': user['password']}
+        login_response = self.client.post('/api/v1/auth/login/', auth_user)
+
+        token = 'JWT ' + login_response.data.get('token')
+        # set authentication token in header
+        self.client.credentials(HTTP_AUTHORIZATION=token)
+
+        # Get to the resources url
+        auth_response = self.client.post(url, entry)
+        import ipdb; ipdb.set_trace()
+        self.assertEqual(auth_response.data.get('text'), 'abcdefgh')
+        self.assertEqual(auth_response.status_code, 201)
+        self.assertNotEqual(plain_response.data, {})
+        self.assertEqual(Resource.objects.count(), 1)
+
+
+    def test_RUD_specific_resource(self):
         plain_response = self.client.get('/api/v1/resources/')
         self.assertEqual(plain_response.data, message)
         self.assertNotEqual(plain_response.data, {})


### PR DESCRIPTION
#### What does this PR do?
Have CRUD on resources endpoint in Codango's REST API
#### Description of Task to be completed?
Have the following endpoints working

`GET /api/v1/resources/`

`POST /api/v1/resources/`

`GET /api/v1/resources/<resource_id>`

`GET /api/v1/resources/?page=<page_number>`

`PUT /api/v1/resources/<resource_id>`

`DELETE /api/v1/resources/<resource_id>`
#### How should this be manually tested?
After cloning the repo, cd into it and RUN `python manage.py test resources`
- Using Postman test every endpoint above with this header:

_key:_ Content-Type _value:_ application/json
- To test authentication, add this to the header:
Get TOKEN from login endpoint

_key:_ Authorization _value:_ JWT [TOKEN] (mind the space between)

#### Any background context you want to provide?
There is implementation of fixtures which is deprecated in Django 1.9 for performance optimization
#### What are the relevant pivotal tracker stories?
#111504508
