### PR TITLE
#121390837 Fix Improper Name Rendering from Facebook Log In

### DIFF
--- a/codango/account/templates/account/layout/base.html
+++ b/codango/account/templates/account/layout/base.html
@@ -43,7 +43,7 @@
                         {% include 'userprofile/partials/activity.html'%}
                     </li>
                     <li class="dropdown">
-                        <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{ request.user.username }} <span class="caret"></span></a>
+                        <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{ rrequest.user.get_full_name|default:request.user.username  }} <span class="caret"></span></a>
                         <ul class="dropdown-menu dropdown-menu-right">
                             <li><a href="/user/{{request.user.username}}">View Profile</a></li>
                             <li><a href="/user/{{request.user.username}}/settings">Settings</a></li>

--- a/codango/account/templates/account/layout/base.html
+++ b/codango/account/templates/account/layout/base.html
@@ -43,7 +43,7 @@
                         {% include 'userprofile/partials/activity.html'%}
                     </li>
                     <li class="dropdown">
-                        <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{ rrequest.user.get_full_name|default:request.user.username  }} <span class="caret"></span></a>
+                        <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{ request.user.get_full_name|default:request.user.username  }} <span class="caret"></span></a>
                         <ul class="dropdown-menu dropdown-menu-right">
                             <li><a href="/user/{{request.user.username}}">View Profile</a></li>
                             <li><a href="/user/{{request.user.username}}/settings">Settings</a></li>


### PR DESCRIPTION
#### What does this PR do?
It fixes improper name rendering from Facebook Login. User full names are now rendered with spaces.

#### Description of Task to be completed?
Modify the base.html page to include user full name

#### How should this be manually tested?
Clicking on the Login with Facebook button

#### Any background context you want to provide?
The feature was functional before. However, users full name are joined together without spaces.

#### What are the relevant pivotal tracker stories?
#121390837 - Name is not rendering properly from Facebook sign up. No spaces

#### Screenshots (if appropriate)
Before Fix:
![before](https://cloud.githubusercontent.com/assets/18309948/16043123/1bb3b382-3236-11e6-82ec-763af07a9fb6.png)

After Fix:
![after](https://cloud.githubusercontent.com/assets/18309948/16043134/271ca1de-3236-11e6-8815-5b60c6438bb4.png)
