### PR TITLE
#121392723 Add new team members to the team page

### DIFF
--- a/codango/account/templates/account/team.html
+++ b/codango/account/templates/account/team.html
@@ -33,11 +33,11 @@
             <div class="col-sm-4">
                 <div class="team-members">
                     <div class="team-avatar">
-                        <img src="https://avatars2.githubusercontent.com/u/13224175?v=3&s=460" class="img-responsive"/>
+                       <img src="https://avatars1.githubusercontent.com/u/3100850?v=3&s=460" class="img-responsive"/>
                     </div>
                     <div class="team-desc">
-                        <a href="https://github.com/andela-ooshodi"><h4>Olufunmilade Oshodi</h4></a>
-                        <span>Developer</span>
+                         <a href="https://github.com/andela-cnnadi"><h4>Chidiebere Nnadi</h4></a>
+                        <span>Team Lead</span>
                     </div>
                 </div>
             </div>
@@ -52,6 +52,19 @@
                     </div>
                 </div>
             </div>
+            <div class="col-sm-4">
+                <div class="team-members">
+                    <div class="team-avatar">
+                        <img src="https://avatars2.githubusercontent.com/u/13224175?v=3&s=460" class="img-responsive"/>
+                    </div>
+                    <div class="team-desc">
+                        <a href="https://github.com/andela-ooshodi"><h4>Olufunmilade Oshodi</h4></a>
+                        <span>Developer</span>
+                    </div>
+                </div>
+            </div>
+          </div>
+          <div class="row">
             <div class="col-sm-4">
                 <div class="team-members">
                     <div class="team-avatar">
@@ -80,12 +93,95 @@
                        <img src="https://avatars2.githubusercontent.com/u/15629602?v=3&s=460" class="img-responsive"/>
                     </div>
                     <div class="team-desc">
-                         <a href="https://github.com/andela-sndagi"><h4>Stan MD</h4></a>
+                         <a href="https://github.com/andela-sndagi"><h4>Stanley Ndagi</h4></a>
                         <span>Developer</span>
                     </div>
                 </div>
             </div>
-        </div>
+          </div>
+          <div class="row">
+            <div class="col-sm-4">
+                <div class="team-members">
+                    <div class="team-avatar">
+                       <img src="https://avatars2.githubusercontent.com/u/12407721?v=3&s=400" class="img-responsive"/>
+                    </div>
+                    <div class="team-desc">
+                         <a href="https://github.com/andela-mochieng"><h4>Margaret Ochieng</h4></a>
+                        <span>Developer</span>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="team-members">
+                    <div class="team-avatar">
+                       <img src="https://avatars0.githubusercontent.com/u/18328313?v=3&s=460" class="img-responsive"/>
+                    </div>
+                    <div class="team-desc">
+                         <a href="https://github.com/andela-snwuguru"><h4>Nwuguru Sunday</h4></a>
+                        <span>Developer</span>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="team-members">
+                    <div class="team-avatar">
+                       <img src="https://avatars3.githubusercontent.com/u/17270426?v=3&s=460" class="img-responsive"/>
+                    </div>
+                    <div class="team-desc">
+                         <a href="https://github.com/andela-aabdulwahab"><h4>Abdulmalik Abdulwahab</h4></a>
+                        <span>Developer</span>
+                    </div>
+                </div>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-sm-4">
+                <div class="team-members">
+                    <div class="team-avatar">
+                       <img src="https://avatars2.githubusercontent.com/u/17288133?v=3&s=460" class="img-responsive"/>
+                    </div>
+                    <div class="team-desc">
+                         <a href="https://github.com/andela-akiura"><h4>Alex Kiura</h4></a>
+                        <span>Developer</span>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="team-members">
+                    <div class="team-avatar">
+                       <img src="https://avatars1.githubusercontent.com/u/18309948?v=3&s=460" class="img-responsive"/>
+                    </div>
+                    <div class="team-desc">
+                         <a href="https://github.com/andela-hoyeboade"><h4>Hassan Oyeboade</h4></a>
+                        <span>Developer</span>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="team-members">
+                    <div class="team-avatar">
+                       <img src="https://avatars2.githubusercontent.com/u/13224913?v=3&s=400" class="img-responsive"/>
+                    </div>
+                    <div class="team-desc">
+                         <a href="https://github.com/IniOluwa"><h4>Ini-Oluwa C. Fageyinbo</h4></a>
+                        <span>Developer</span>
+                    </div>
+                </div>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-sm-4 col-sm-offset-4">
+              <div class="team-members">
+                  <div class="team-avatar">
+                     <img src="https://avatars1.githubusercontent.com/u/9017229?v=3&s=460" class="img-responsive"/>
+                  </div>
+                  <div class="team-desc">
+                       <a href="https://github.com/Achile"><h4>Achile Egbunu</h4></a>
+                      <span>Developer</span>
+                  </div>
+              </div>
+            </div>
+          </div>
     </div>
 </div>
 {% endblock body %}

--- a/codango/account/templates/account/team.html
+++ b/codango/account/templates/account/team.html
@@ -42,6 +42,81 @@
                 </div>
             </div>
             <div class="col-sm-4">
+              <div class="team-members">
+                  <div class="team-avatar">
+                     <img src="https://avatars2.githubusercontent.com/u/15629602?v=3&s=460" class="img-responsive"/>
+                  </div>
+                  <div class="team-desc">
+                       <a href="https://github.com/andela-sndagi"><h4>Stanley Ndagi</h4></a>
+                      <span>Developer</span>
+                  </div>
+              </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="team-members">
+                    <div class="team-avatar">
+                       <img src="https://avatars2.githubusercontent.com/u/12407721?v=3&s=400" class="img-responsive"/>
+                    </div>
+                    <div class="team-desc">
+                         <a href="https://github.com/andela-mochieng"><h4>Margaret Ochieng</h4></a>
+                        <span>Developer</span>
+                    </div>
+                </div>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-sm-4">
+              <div class="team-members">
+                  <div class="team-avatar">
+                     <img src="https://avatars3.githubusercontent.com/u/17270426?v=3&s=460" class="img-responsive"/>
+                  </div>
+                  <div class="team-desc">
+                       <a href="https://github.com/andela-aabdulwahab"><h4>Abdulmalik Abdulwahab</h4></a>
+                      <span>Developer</span>
+                  </div>
+              </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="team-members">
+                    <div class="team-avatar">
+                       <img src="https://avatars2.githubusercontent.com/u/17288133?v=3&s=460" class="img-responsive"/>
+                    </div>
+                    <div class="team-desc">
+                         <a href="https://github.com/andela-akiura"><h4>Alex Kiura</h4></a>
+                        <span>Developer</span>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-4">
+                <div class="team-members">
+                    <div class="team-avatar">
+                       <img src="https://avatars1.githubusercontent.com/u/18309948?v=3&s=460" class="img-responsive"/>
+                    </div>
+                    <div class="team-desc">
+                         <a href="https://github.com/andela-hoyeboade"><h4>Hassan Oyeboade</h4></a>
+                        <span>Developer</span>
+                    </div>
+                </div>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-sm-4">
+                <div class="team-members">
+                    <div class="team-avatar">
+                       <img src="https://avatars0.githubusercontent.com/u/18328313?v=3&s=460" class="img-responsive"/>
+                    </div>
+                    <div class="team-desc">
+                         <a href="https://github.com/andela-snwuguru"><h4>Nwuguru Sunday</h4></a>
+                        <span>Developer</span>
+                    </div>
+                </div>
+            </div>
+          </div>
+          <div class="heading">
+              <h1 class="page-title">Hall Of Fame</h1>
+          </div>
+          <div class="row">
+            <div class="col-sm-4">
                 <div class="team-members">
                     <div class="team-avatar">
                         <img src="https://avatars2.githubusercontent.com/u/13223950?v=3&s=460" class="img-responsive"/>
@@ -62,6 +137,17 @@
                         <span>Developer</span>
                     </div>
                 </div>
+            </div>
+            <div class="col-sm-4">
+              <div class="team-members">
+                  <div class="team-avatar">
+                     <img src="https://avatars1.githubusercontent.com/u/9017229?v=3&s=460" class="img-responsive"/>
+                  </div>
+                  <div class="team-desc">
+                       <a href="https://github.com/Achile"><h4>Achile Egbunu</h4></a>
+                      <span>Developer</span>
+                  </div>
+              </div>
             </div>
           </div>
           <div class="row">
@@ -90,76 +176,6 @@
             <div class="col-sm-4">
                 <div class="team-members">
                     <div class="team-avatar">
-                       <img src="https://avatars2.githubusercontent.com/u/15629602?v=3&s=460" class="img-responsive"/>
-                    </div>
-                    <div class="team-desc">
-                         <a href="https://github.com/andela-sndagi"><h4>Stanley Ndagi</h4></a>
-                        <span>Developer</span>
-                    </div>
-                </div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-sm-4">
-                <div class="team-members">
-                    <div class="team-avatar">
-                       <img src="https://avatars2.githubusercontent.com/u/12407721?v=3&s=400" class="img-responsive"/>
-                    </div>
-                    <div class="team-desc">
-                         <a href="https://github.com/andela-mochieng"><h4>Margaret Ochieng</h4></a>
-                        <span>Developer</span>
-                    </div>
-                </div>
-            </div>
-            <div class="col-sm-4">
-                <div class="team-members">
-                    <div class="team-avatar">
-                       <img src="https://avatars0.githubusercontent.com/u/18328313?v=3&s=460" class="img-responsive"/>
-                    </div>
-                    <div class="team-desc">
-                         <a href="https://github.com/andela-snwuguru"><h4>Nwuguru Sunday</h4></a>
-                        <span>Developer</span>
-                    </div>
-                </div>
-            </div>
-            <div class="col-sm-4">
-                <div class="team-members">
-                    <div class="team-avatar">
-                       <img src="https://avatars3.githubusercontent.com/u/17270426?v=3&s=460" class="img-responsive"/>
-                    </div>
-                    <div class="team-desc">
-                         <a href="https://github.com/andela-aabdulwahab"><h4>Abdulmalik Abdulwahab</h4></a>
-                        <span>Developer</span>
-                    </div>
-                </div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-sm-4">
-                <div class="team-members">
-                    <div class="team-avatar">
-                       <img src="https://avatars2.githubusercontent.com/u/17288133?v=3&s=460" class="img-responsive"/>
-                    </div>
-                    <div class="team-desc">
-                         <a href="https://github.com/andela-akiura"><h4>Alex Kiura</h4></a>
-                        <span>Developer</span>
-                    </div>
-                </div>
-            </div>
-            <div class="col-sm-4">
-                <div class="team-members">
-                    <div class="team-avatar">
-                       <img src="https://avatars1.githubusercontent.com/u/18309948?v=3&s=460" class="img-responsive"/>
-                    </div>
-                    <div class="team-desc">
-                         <a href="https://github.com/andela-hoyeboade"><h4>Hassan Oyeboade</h4></a>
-                        <span>Developer</span>
-                    </div>
-                </div>
-            </div>
-            <div class="col-sm-4">
-                <div class="team-members">
-                    <div class="team-avatar">
                        <img src="https://avatars2.githubusercontent.com/u/13224913?v=3&s=400" class="img-responsive"/>
                     </div>
                     <div class="team-desc">
@@ -167,19 +183,6 @@
                         <span>Developer</span>
                     </div>
                 </div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-sm-4 col-sm-offset-4">
-              <div class="team-members">
-                  <div class="team-avatar">
-                     <img src="https://avatars1.githubusercontent.com/u/9017229?v=3&s=460" class="img-responsive"/>
-                  </div>
-                  <div class="team-desc">
-                       <a href="https://github.com/Achile"><h4>Achile Egbunu</h4></a>
-                      <span>Developer</span>
-                  </div>
-              </div>
             </div>
           </div>
     </div>

--- a/codango/account/templates/account/team.html
+++ b/codango/account/templates/account/team.html
@@ -90,10 +90,10 @@
             <div class="col-sm-4">
                 <div class="team-members">
                     <div class="team-avatar">
-                       <img src="https://avatars1.githubusercontent.com/u/18309948?v=3&s=460" class="img-responsive"/>
+                       <img src="https://avatars0.githubusercontent.com/u/18328313?v=3&s=460" class="img-responsive"/>
                     </div>
                     <div class="team-desc">
-                         <a href="https://github.com/andela-hoyeboade"><h4>Hassan Oyeboade</h4></a>
+                         <a href="https://github.com/andela-snwuguru"><h4>Nwuguru Sunday</h4></a>
                         <span>Developer</span>
                     </div>
                 </div>
@@ -103,10 +103,10 @@
             <div class="col-sm-4">
                 <div class="team-members">
                     <div class="team-avatar">
-                       <img src="https://avatars0.githubusercontent.com/u/18328313?v=3&s=460" class="img-responsive"/>
+                       <img src="https://avatars1.githubusercontent.com/u/18309948?v=3&s=460" class="img-responsive"/>
                     </div>
                     <div class="team-desc">
-                         <a href="https://github.com/andela-snwuguru"><h4>Nwuguru Sunday</h4></a>
+                         <a href="https://github.com/andela-hoyeboade"><h4>Hassan Oyeboade</h4></a>
                         <span>Developer</span>
                     </div>
                 </div>


### PR DESCRIPTION
### What does this PR do?

Update the Team Page to include the new members of the team

### Description of Task to be completed?

The team page shows the information of everyone working on the team. With past members commemorated in the Hall of fame section. 

### How should this be manually tested?

Information found on the team page can be compared to the authors listed in the new README section.

### Any background context you want to provide?

Many of the current team members working on the page don't have their information on the team page.

### What are the relevant pivotal tracker stories?
#121392723

### Preview of the completed team page
![codangoteam](https://cloud.githubusercontent.com/assets/17270426/16067777/75ac17ae-32b7-11e6-88f0-de8af4d2bfca.png)