### PR TITLE
#126965745 Fix user profile to show followers users they follow

### DIFF
--- a/codango/userprofile/templates/userprofile/partials/follow_list.html
+++ b/codango/userprofile/templates/userprofile/partials/follow_list.html
@@ -2,24 +2,32 @@
 <div class="content-block">
     <div class="panel-heading" id="followers-heading">
         <div class="page-title">{{direction|title}}</div>
-         <div class="row" id="followers-detail">
-        {% for following in follow_list %}
-       
-            <div class="col-sm-4 text-center">
-                {% if following.followed.profile.image %} 
-                {% cloudinary following.profile.image width=150 height=150 class="img-responsive" crop="fill" %} 
-                {% else %} 
-                {% cloudinary "vqr7n59zfxyeybttleug.gif" width=150 height=150 crop="fill" %} 
-                {% endif %}
-                <br/>
-                <span>
-                    <a href="/user/{{ following }}" id="follower-name">{{ following }}</a>
-                </span>
-            </div>
-   
-        {% empty %} 
-        {{ no_follow }} 
-        {% endfor %}
-             </div>
+        <div class="row" id="followers-detail">
+            {% for following in follow_list %}
+                <div class="col-sm-4 text-center">
+                    {% if direction == 'following' %}
+                        {% if following.followed.profile.image %}
+                            {% cloudinary following.followed.profile.image width=150 height=150 class="img-responsive" crop="fill" %}
+                        {% else %}
+                            {% cloudinary "vqr7n59zfxyeybttleug.gif" width=150 height=150 crop="fill" %}
+                        {% endif %}
+                        <span>
+                            <a href="/user/{{ following.followed.username }}" id="follower-name">{{ following.followed.username }}</a>
+                        </span>
+                    {% else %}
+                        {% if following.follower.profile.image %}
+                            {% cloudinary following.follower.profile.image width=150 height=150 class="img-responsive" crop="fill" %}
+                        {% else %}
+                            {% cloudinary "vqr7n59zfxyeybttleug.gif" width=150 height=150 crop="fill" %}
+                        {% endif %}
+                        <span>
+                            <a href="/user/{{ following.follower.username }}" id="follower-name">{{ following.follower.username }}</a>
+                        </span>
+                    {% endif %}
+                </div>
+            {% empty %}
+            {{ no_follow }}
+            {% endfor %}
+          </div>
     </div>
 </div>

--- a/codango/userprofile/templates/userprofile/partials/user-profile.html
+++ b/codango/userprofile/templates/userprofile/partials/user-profile.html
@@ -66,7 +66,7 @@
                     <p class="text-center">
                         <a href="/user/{{ profile.user.username }}/following">
                             <small>
-                            {% if profile.get_followers|length > 1 %}Following{% else %}Follower{% endif %}
+                            {% if profile.get_followers|length >= 1 %}Following{% else %}Follower{% endif %}
                             </small>
                         </a>
                     </p>


### PR DESCRIPTION
#### What does this PR do?
It displays the username of a user's followers and the people they follow
#### Description of Task to be completed?
Fix bug preventing the correct display of the username of a user's followers and the people they follow.
#### How should this be manually tested?
By clicking on a user's followers or people they follow on their profile.

#### What are the relevant pivotal tracker stories?
#126965745- Fix user profile to show followers and the ones they follow.

#### Screenshots
Before 
<img width="938" alt="screen shot 2016-08-03 at 17 17 38" src="https://cloud.githubusercontent.com/assets/17288133/17368730/f605ff98-599d-11e6-919b-e9c0b2292206.png">


After
<img width="898" alt="screen shot 2016-08-03 at 17 20 19" src="https://cloud.githubusercontent.com/assets/17288133/17368808/54e119d0-599e-11e6-9c69-4b12aff61898.png">
