### PR TITLE
[Feature #128049967] Implement 'apps addon' model

### DIFF
--- a/codango/community/migrations/0006_auto_20160921_1342.py
+++ b/codango/community/migrations/0006_auto_20160921_1342.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import multiselectfield.db.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('community', '0005_auto_20160830_1052'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='AddOnModel',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('date_created', models.DateTimeField(auto_now_add=True)),
+                ('date_modified', models.DateTimeField(auto_now=True)),
+                ('name', models.CharField(max_length=50)),
+            ],
+            options={
+                'ordering': ['name'],
+            },
+        ),
+        migrations.AlterField(
+            model_name='community',
+            name='default_group_permissions',
+            field=multiselectfield.db.fields.MultiSelectField(default=[b'BLOCK_MEMBER'], max_length=55, verbose_name=b'Default Members Permissions', choices=[(b'INVITE_MEMBER', b'Send invites'), (b'DELETE_MEMBER', b'Remove members'), (b'BLOCK_MEMBER', b'Block members'), (b'SUSPEND_MEMBER', b'Suspend members')]),
+        ),
+        migrations.AlterField(
+            model_name='community',
+            name='description',
+            field=models.TextField(max_length=1000),
+        ),
+        migrations.AlterField(
+            model_name='community',
+            name='name',
+            field=models.CharField(max_length=50),
+        ),
+        migrations.AlterField(
+            model_name='community',
+            name='private',
+            field=models.BooleanField(default=False, verbose_name=b'Private (Default is Public)'),
+        ),
+        migrations.AlterField(
+            model_name='community',
+            name='visibility',
+            field=models.CharField(default=b'full', max_length=30, choices=[(b'none', b'None'), (b'partial', b'Partial'), (b'full', b'Full')]),
+        ),
+        migrations.AlterField(
+            model_name='communityblacklist',
+            name='blacklist_type',
+            field=models.CharField(default=b'Block', max_length=20, choices=[(b'block', b'Block'), (b'suspend', b'Suspend')]),
+        ),
+        migrations.AlterField(
+            model_name='communitymember',
+            name='permission',
+            field=multiselectfield.db.fields.MultiSelectField(default=[b'BLOCK_MEMBER'], max_length=55, choices=[(b'INVITE_MEMBER', b'Send invites'), (b'DELETE_MEMBER', b'Remove members'), (b'BLOCK_MEMBER', b'Block members'), (b'SUSPEND_MEMBER', b'Suspend members')]),
+        ),
+        migrations.AddField(
+            model_name='addonmodel',
+            name='communities',
+            field=models.ManyToManyField(to='community.Community'),
+        ),
+    ]

--- a/codango/community/migrations/0007_auto_20160921_1344.py
+++ b/codango/community/migrations/0007_auto_20160921_1344.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('community', '0006_auto_20160921_1342'),
+    ]
+
+    operations = [
+        migrations.RenameModel(
+            old_name='AddOnModel',
+            new_name='AddOn',
+        ),
+    ]

--- a/codango/community/models.py
+++ b/codango/community/models.py
@@ -109,3 +109,14 @@ class CommunityBlacklist(TimeStampMixin):
 
     class Meta:
         ordering = ['-date_modified']
+
+
+class AddOn(TimeStampMixin):
+    name = models.CharField(max_length=50)
+    communities = models.ManyToManyField(Community)
+
+    def __str__(self):
+        return '{}'.format(self.name)
+
+    class Meta:
+        ordering = ['name']

--- a/codango/community/tests/test_models.py
+++ b/codango/community/tests/test_models.py
@@ -1,0 +1,85 @@
+from django.contrib.auth.models import User
+from django.core.exceptions import ObjectDoesNotExist
+from django.test import TestCase
+
+from community.models import AddOn
+from community.models import Community, Tag
+
+
+class AddonModelTestSuite(TestCase):
+    def setUp(self):
+        self.user = User.objects.create(
+            username="regularjoe",
+            email="regularjoe@yahoo.com",
+            password="regularjoepass"
+        )
+
+        tag = Tag.objects.create(title="Python")
+        self.community_python = Community.objects.create(
+            name="pythonistas",
+            description="A chill place for python lovers",
+            creator=self.user
+        )
+        self.community_python.tags.add(tag)
+        self.community_ruby = Community.objects.create(
+            name="Ruby Tabernacle",
+            description="We eat gems and talk ruby",
+            creator=self.user
+        )
+        self.community_ruby.tags.add(tag)
+
+        self.addon_statistics = AddOn.objects.create(name="statistics")
+        self.addon_bots = AddOn.objects.create(name="bots")
+        self.addon_statistics.communities.add(self.community_python)
+
+    def test_can_create_addon(self):
+        addon = AddOn.objects.create(name="pairprogram")
+        self.assertIsInstance(addon, AddOn)
+        self.assertIsNotNone(addon.id)
+        self.assertIsNotNone(addon.name)
+
+    def test_can_read_addon(self):
+        addon = AddOn.objects.get(name="statistics")
+        self.assertIsInstance(addon, AddOn)
+
+    def test_can_update_addon(self):
+        addon = AddOn.objects.get(name="statistics")
+        addon.name = "analytics"
+        addon.save()
+        addon = AddOn.objects.get(name="analytics")
+        self.assertEqual(addon.id, self.addon_statistics.id)
+        self.assertEqual(addon.name, "analytics")
+
+    def test_can_delete_addon(self):
+        addon = AddOn.objects.get(name="statistics")
+        addon.delete()
+        self.assertRaises(
+            ObjectDoesNotExist,
+            AddOn.objects.get,
+            pk=self.addon_statistics.id
+        )
+
+    def test_can_read_community_from_addon(self):
+        addon = AddOn.objects.get(name="statistics")
+        community = addon.communities.get(name="pythonistas")
+        self.assertIsInstance(community, Community)
+
+    def test_can_add_community_to_addon(self):
+        self.addon_bots.communities.add(self.community_ruby)
+        community = self.addon_bots.communities.get(name="Ruby Tabernacle")
+        self.assertEqual(community, self.community_ruby)
+
+    def test_can_add_multiple_communities_to_addon(self):
+        self.addon_statistics.communities.add(self.community_ruby)
+        self.assertEqual(self.addon_statistics.communities.all().count(), 2)
+
+    def test_can_remove_addon_from_community(self):
+        self.addon_statistics.communities.remove(self.community_python)
+        self.assertEqual(self.addon_statistics.communities.all().count(), 0)
+
+    def test_add_invalid_object_to_addon(self):
+        self.assertRaises(
+            TypeError,
+            self.addon_statistics.communities.add,
+            self.user
+        )


### PR DESCRIPTION
## What does this PR do?
Implements an "apps addon" model

## Description of task to be completed:
Implement an 'apps addon' model that will be used to add app-addons to communities

## How should this be manually tested?
Navigate to the _codango_ app directory
`cd codango`
Migrate the database
`python manage.py makemigrations`
`python manage.py migrate`
Test the functionality
`python manage.py test community.tests.test_models`

## What are the relevant pivotal tracker stories?
[#128049967](https://www.pivotaltracker.com/story/show/128049967)